### PR TITLE
fix InternalCachedFlagsStorage exceptions logging key when Proguard is enabled

### DIFF
--- a/feature-manager/src/main/java/com/qiwi/featuretoggle/storage/InternalCachedFlagsStorage.kt
+++ b/feature-manager/src/main/java/com/qiwi/featuretoggle/storage/InternalCachedFlagsStorage.kt
@@ -57,7 +57,7 @@ internal class InternalCachedFlagsStorage(
                 converter.convertFeatureFlag(
                     entry.key as String,
                     entry.value as Any,
-                    javaClass.simpleName,
+                    KEY,
                     registry,
                     logger
                 )
@@ -79,5 +79,7 @@ internal class InternalCachedFlagsStorage(
 
     companion object {
         const val DEFAULT_FILE_NAME = "flags.json"
+
+        const val KEY = "InternalCachedFlagsStorage"
     }
 }


### PR DESCRIPTION
Fixes issue when exceptions from `InternalCachedFlagsStorage` appeared in `Logger` with obfuscated key.